### PR TITLE
feat(propeties): agrega depencias de mysql y spring web

### DIFF
--- a/marly-handmade-backend/pom.xml
+++ b/marly-handmade-backend/pom.xml
@@ -40,6 +40,27 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/marly-handmade-backend/src/main/resources/application.properties
+++ b/marly-handmade-backend/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 spring.application.name=marly-handmade-backend
+spring.datasource.url=${URL_BD}
+spring.datasource.username=${USER_BD}
+spring.datasource.password=${PASSWORD_BD}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
### 📄 Cuerpo del PR:

- 🎯 **Descripción:**  
    agrega depencias de mysql y spring web para poder conectarte a la base de datos

- ✨ **Cambios realizados:**  
    - agregue dependencia de mysql en properties
    - agregue depencia de spring web en properties

- 🧪 **Pasos para probar:**  
    1.  dirigirte a la carpeta marly-handmade-backend  
    2. entrar a al archivo pom.xml  
    3.  dirigete a al archivo application.properties
    4. verificar que esta conectado a la base de datos con la url, username, password

- ⚠️ **Impacto/Riesgos:**  
    - si no se comprueba que se conecto la base de datos puede haber conflictos al momento de ejecutar el proyecto de backend
