### PR TITLE
feat(PaginasFooter): agregue paginas y conexión que contiene el footer para otras paginas

### DIFF
--- a/marly-handmade-frontend/src/App.jsx
+++ b/marly-handmade-frontend/src/App.jsx
@@ -14,6 +14,13 @@ import TermsConditions from "./pages/TermsConditions";
 import SeaCollectionDetail from "./pages/SeaColletionDetail";
 import RecoverPassword from "./pages/RecoverPassword";
 import Product from "./pages/Product";
+import PrivacyPolicy from "./pages/PrivacyPolicy.jsx";
+import ShippingPolicy from "./pages/ShippingPolicy.jsx";
+import ExchangePolicy from "./pages/ExchangePolicy.jsx";
+import FAQ from "./pages/FAQ.jsx";
+import OurStory from "./pages/OurStory.jsx";
+import ContactUs from "./pages/ContactUs.jsx";
+import Returns from "./pages/Returns.jsx";
 
 import ConfirmNewPassword from "./pages/ConfirmNewPassword";
 import Dashboard from "./pages/AdminDashboard";
@@ -48,6 +55,14 @@ function App() {
         <Route path="/recover-password" element={<RecoverPassword />} />
         <Route path="/product" element={<Product />} />
         <Route path="/product/sea-collection" element={<SeaCollectionDetail />} />
+        <Route path="/privacy" element={<PrivacyPolicy />} />
+        <Route path="/shipping-policy" element={<ShippingPolicy />} />
+        <Route path="/exchange" element={<ExchangePolicy />} />
+        <Route path="/faq" element={<FAQ />} />
+        <Route path="/our-story" element={<OurStory />} />
+        <Route path="/contact" element={<ContactUs />} />
+        <Route path="/returns" element={<Returns />} />
+        <Route path="/shop" element={<SeaCollectionDetail />} />
 
         {/* ADMIN */}
         <Route path="/admin/dashboard" element={<Dashboard />} />

--- a/marly-handmade-frontend/src/pages/ContactUs.jsx
+++ b/marly-handmade-frontend/src/pages/ContactUs.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+import { Mail, Phone } from "lucide-react";
+
+function ContactUs() {
+  return (
+    <>
+      <Header />
+      <div className="my-20 mx-auto w-[60%] text-center font-serif">
+        <h2 className="text-3xl font-bold mb-8 text-[#040F2E]">CONTACT US</h2>
+        <p className="text-xl mb-6 font-semibold">MARLY Handmade Jewelry</p>
+
+        <div className="flex items-center justify-center space-x-3 mb-4">
+          <Phone className="w-6 h-6 text-[#2C3E5E]" />
+          <span className="text-lg text-[#2C3E5E]">+51 987 654 321</span>
+        </div>
+
+        <div className="flex items-center justify-center space-x-3 mb-4">
+          <Mail className="w-6 h-6 text-[#2C3E5E]" />
+          <span className="text-lg text-[#2C3E5E]">contactmarly@gmail.com</span>
+        </div>
+
+        <p className="mt-6 text-gray-500 text-sm">
+          Our customer service team is available Mon – Fri, 10 AM – 6 PM.
+        </p>
+      </div>
+      <Footer />
+    </>
+  );
+}
+
+export default ContactUs;

--- a/marly-handmade-frontend/src/pages/ExchangePolicy.jsx
+++ b/marly-handmade-frontend/src/pages/ExchangePolicy.jsx
@@ -1,0 +1,44 @@
+import React from "react";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+import ConditionsComponet from "../components/ConditionsComponet";
+
+function ExchangePolicy() {
+  let conditions = [
+    [
+      "MARLY Jewelry offers exchanges and repairs to ensure customer satisfaction with our handcrafted jewelry.",
+      "Requests for exchanges or repairs must be made within 7 days of receiving the product.",
+      "Items that have been used, damaged, or personalized cannot be exchanged or repaired.",
+    ],
+    [
+      "To initiate an exchange or repair, contact our customer service at contactmarly@gmail.com with your order number and a brief description of the issue.",
+      "Our team will provide instructions for returning the item safely and for receiving your replacement or repaired jewelry.",
+    ],
+    [
+      "Shipping costs for exchanges or repairs may be covered by MARLY Jewelry if the item is defective or damaged.",
+      "For non-defective exchanges, the client is responsible for return shipping.",
+    ],
+  ];
+
+  return (
+    <>
+      <Header />
+      <h2 className="text-2xl xs:text-3xl font-bold mb-8 whitespace-nowrap text-center mt-15">
+        EXCHANGE & REPAIR POLICY
+      </h2>
+      <div className="my-20 mx-auto w-[60%]">
+        <p>
+          MARLY Jewelry strives to ensure every piece reaches you in perfect condition. 
+          Our Exchange & Repair Policy allows you to request replacements or repairs 
+          if your order does not meet your expectations or has manufacturing defects.
+        </p>
+        <ConditionsComponet titulo="Exchanges and Repairs" subtitulos={conditions[0]} />
+        <ConditionsComponet titulo="How to Request" subtitulos={conditions[1]} />
+        <ConditionsComponet titulo="Shipping and Costs" subtitulos={conditions[2]} />
+      </div>
+      <Footer />
+    </>
+  );
+}
+
+export default ExchangePolicy;

--- a/marly-handmade-frontend/src/pages/FAQ.jsx
+++ b/marly-handmade-frontend/src/pages/FAQ.jsx
@@ -1,0 +1,79 @@
+import React, { useState } from "react";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+
+function FAQ() {
+  const faqs = [
+    {
+      question: "How can I track my order?",
+      answer:
+        "Once your order is shipped, we will send you a tracking number via email. You can use it to track your package online.",
+    },
+    {
+      question: "What is the return and exchange policy?",
+      answer:
+        "MARLY Jewelry allows exchanges and repairs within 7 days of delivery for items with defects. Personalized or used items cannot be exchanged.",
+    },
+    {
+      question: "Do you ship internationally?",
+      answer:
+        "Yes! We ship worldwide. Shipping times and fees vary depending on the destination country.",
+    },
+    {
+      question: "How do I care for my jewelry?",
+      answer:
+        "Avoid contact with perfumes, water, detergents, and direct sunlight. Store your pieces in a soft pouch when not in use.",
+    },
+    {
+      question: "Can I cancel my order?",
+      answer:
+        "Orders can be canceled within 24 hours of purchase. After that, please contact us for assistance.",
+    },
+  ];
+
+  return (
+    <>
+      <Header />
+      <h2 className="text-2xl xs:text-3xl font-bold mb-8 whitespace-nowrap text-center mt-15">
+        FREQUENTLY ASKED QUESTIONS
+      </h2>
+      <div className="my-20 mx-auto w-[60%] font-serif space-y-4">
+        {faqs.map((faq, index) => (
+          <AccordionItem key={index} question={faq.question} answer={faq.answer} />
+        ))}
+      </div>
+      <Footer />
+    </>
+  );
+}
+
+// Componente de acordeón
+function AccordionItem({ question, answer }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="border border-gray-300 rounded-md overflow-hidden">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full flex justify-between items-center px-4 py-3 bg-gray-100 hover:bg-gray-200 focus:outline-none"
+      >
+        <span className="font-semibold">{question}</span>
+        <span
+          className={`transform transition-transform duration-300 ${
+            isOpen ? "rotate-90" : "rotate-0"
+          }`}
+        >
+          ▶
+        </span>
+      </button>
+      {isOpen && (
+        <div className="px-4 py-3 bg-white text-gray-700">
+          {answer}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default FAQ;
+

--- a/marly-handmade-frontend/src/pages/OurStory.jsx
+++ b/marly-handmade-frontend/src/pages/OurStory.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+import ConditionsComponet from "../components/ConditionsComponet";
+
+function OurStory() {
+  let sections = [
+    [
+      "MARLY handmade was founded in 2020 with a passion for unique, high-quality jewelry.",
+      "Our mission is to bring artisanal craftsmanship and creativity to every piece, from delicate pearls to elegant pendants.",
+      "Each piece is carefully designed to tell a story and connect with our customers."
+    ],
+    [
+      "We work closely with skilled artisans to ensure that every item reflects our commitment to quality and beauty.",
+      "Materials are carefully selected, combining classic elegance with modern design trends."
+    ],
+    [
+      "Over the years, MARLY has grown into a brand known for attention to detail and personalized customer experience.",
+      "We believe jewelry should not only adorn but also inspire, celebrating life's special moments."
+    ],
+    [
+      "Sustainability and ethical practices are core to our process, from sourcing materials to packaging.",
+      "We aim to reduce waste and ensure that our products are made responsibly."
+    ]
+  ];
+
+  return (
+    <>
+      <Header />
+      <h2 className="text-2xl xs:text-3xl font-bold mb-8 whitespace-nowrap text-center mt-15">
+        OUR STORY
+      </h2>
+      <div className="my-20 mx-auto w-[60%] font-serif">
+        <p className="mb-8">
+          At MARLY handmade, every piece of jewelry has a story. From humble beginnings to a recognized artisanal brand, our journey is inspired by passion, creativity, and dedication to craftsmanship.
+        </p>
+        <ConditionsComponet titulo="The Beginning" subtitulos={sections[0]} />
+        <ConditionsComponet titulo="Craftsmanship and Materials" subtitulos={sections[1]} />
+        <ConditionsComponet titulo="Growth and Vision" subtitulos={sections[2]} />
+        <ConditionsComponet titulo="Sustainability and Ethics" subtitulos={sections[3]} />
+      </div>
+      <Footer />
+    </>
+  );
+}
+
+export default OurStory;

--- a/marly-handmade-frontend/src/pages/PrivacyPolicy.jsx
+++ b/marly-handmade-frontend/src/pages/PrivacyPolicy.jsx
@@ -1,0 +1,55 @@
+import React from "react";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+import ConditionsComponet from "../components/ConditionsComponet";
+
+function PrivacyPolicy() {
+  let conditions = [
+    [
+      "At MARLY Jewelry, we value the trust of our clients and are committed to protecting their personal data.",
+      "All information collected through our website or social media channels is used exclusively for order processing, customer service, and promotional purposes.",
+      "We comply with Law No. 29733 (Peru) on the Protection of Personal Data, ensuring transparency and security in every transaction.",
+    ],
+    [
+      "Personal information may include your name, contact details, purchase history, and payment information.",
+      "We use this data solely for internal purposes, to improve our products and shopping experience.",
+      "Sensitive payment data is processed through secure platforms and is never stored directly on our servers.",
+    ],
+    [
+      "Users have the right to access, correct, update, or delete their personal data by contacting us at contactmarly@gmail.com.",
+      "Upon request, MARLY Jewelry will delete user information, except in cases required by law (e.g., invoices or tax documentation).",
+    ],
+    [
+      "We may send you newsletters or updates only if you have voluntarily subscribed to them.",
+      "You can unsubscribe at any time by clicking the link at the bottom of our emails.",
+    ],
+    [
+      "MARLY Jewelry guarantees that no personal data will be shared with third parties without explicit customer consent, unless legally required.",
+      "In cases of collaboration with logistics or marketing partners, only essential data is shared under confidentiality agreements.",
+    ],
+  ];
+
+  return (
+    <>
+      <Header />
+      <h2 className="text-2xl xs:text-3xl font-bold mb-8 whitespace-nowrap text-center mt-15">
+        PRIVACY POLICY
+      </h2>
+      <div className="my-20 mx-auto w-[60%]">
+        <p>
+          MARLY Jewelry is committed to safeguarding the privacy of all customers.
+          This policy explains how we collect, use, and protect personal data during your
+          shopping experience with us.
+        </p>
+        <ConditionsComponet titulo="A. Data Protection Commitment" subtitulos={conditions[0]} />
+        <ConditionsComponet titulo="B. Information Collected" subtitulos={conditions[1]} />
+        <ConditionsComponet titulo="C. User Rights" subtitulos={conditions[2]} />
+        <ConditionsComponet titulo="D. Communication and Newsletters" subtitulos={conditions[3]} />
+        <ConditionsComponet titulo="E. Data Sharing and Security" subtitulos={conditions[4]} />
+      </div>
+      <Footer />
+    </>
+  );
+}
+
+export default PrivacyPolicy;

--- a/marly-handmade-frontend/src/pages/Returns.jsx
+++ b/marly-handmade-frontend/src/pages/Returns.jsx
@@ -1,0 +1,49 @@
+import React from "react";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+import ConditionsComponet from "../components/ConditionsComponet";
+
+function Returns() {
+  const sections = [
+    [
+      "MARLY Handmade Jewelry allows returns and exchanges within 7 days of delivery for defective items or shipping errors.",
+      "Products that have been used, damaged, or personalized cannot be returned or exchanged.",
+      "To request a return, contact us at contactmarly@gmail.com with your order number and details of the issue.",
+    ],
+    [
+      "For exchanges, you can select another product of equal value, subject to availability.",
+      "If the replacement item is more expensive, the difference must be paid. If it is cheaper, no refund is provided for the difference.",
+    ],
+    [
+      "MARLY Jewelry offers repair services for damaged or defective pieces.",
+      "Repairs may take 7-14 business days depending on the complexity of the work.",
+      "Return shipping costs for defective items are covered by MARLY; for non-defective items, the client is responsible for shipping.",
+    ],
+    [
+      "All requests for returns, exchanges, or repairs must be accompanied by the original receipt or invoice.",
+      "Items should be returned in their original packaging whenever possible to avoid further damage.",
+    ],
+  ];
+
+  return (
+    <>
+      <Header />
+      <h2 className="text-2xl xs:text-3xl font-bold mb-8 whitespace-nowrap text-center mt-15">
+        RETURNS, EXCHANGES & REPAIRS
+      </h2>
+      <div className="my-20 mx-auto w-[60%] font-serif">
+        <p className="mb-8">
+          At MARLY Handmade Jewelry, we aim to ensure every customer is satisfied with their purchase. 
+          This policy explains how to return, exchange, or repair your jewelry safely and efficiently.
+        </p>
+        <ConditionsComponet titulo="Returns" subtitulos={sections[0]} />
+        <ConditionsComponet titulo="Exchanges" subtitulos={sections[1]} />
+        <ConditionsComponet titulo="Repairs" subtitulos={sections[2]} />
+        <ConditionsComponet titulo="Requirements" subtitulos={sections[3]} />
+      </div>
+      <Footer />
+    </>
+  );
+}
+
+export default Returns;

--- a/marly-handmade-frontend/src/pages/ShippingPolicy.jsx
+++ b/marly-handmade-frontend/src/pages/ShippingPolicy.jsx
@@ -1,0 +1,55 @@
+import React from "react";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+import ConditionsComponet from "../components/ConditionsComponet";
+
+function ShippingPolicy() {
+  let conditions = [
+    [
+      "MARLY Jewelry ensures that all orders are shipped with care and arrive safely to our clients.",
+      "Shipping times may vary depending on your location and the availability of the selected products.",
+      "We are not responsible for delays caused by courier services, customs, or natural events beyond our control.",
+    ],
+    [
+      "Domestic shipments are usually delivered within 3-7 business days.",
+      "International shipments may take 10-20 business days depending on customs procedures and destination country.",
+      "Tracking numbers will be provided once the order is dispatched.",
+    ],
+    [
+      "All packages are securely packaged to prevent damage during transport.",
+      "MARLY Jewelry takes care to ensure fragile items, such as pearls or delicate pendants, are properly protected.",
+      "In the unlikely event of damage during shipping, contact us immediately at contactmarly@gmail.com.",
+    ],
+    [
+      "Additional shipping fees may apply for remote locations or oversized orders.",
+      "Free shipping promotions are subject to terms and conditions stated at checkout.",
+    ],
+    [
+      "Customers must provide accurate delivery information to avoid delays.",
+      "MARLY Jewelry is not responsible for shipments lost or delayed due to incorrect addresses provided by the client.",
+    ],
+  ];
+
+  return (
+    <>
+      <Header />
+      <h2 className="text-2xl xs:text-3xl font-bold mb-8 whitespace-nowrap text-center mt-15">
+        SHIPPING POLICY
+      </h2>
+      <div className="my-20 mx-auto w-[60%]">
+        <p>
+          MARLY Jewelry is committed to delivering your jewelry safely and on time. 
+          This policy outlines how we handle shipments, delivery times, and customer responsibilities to ensure a smooth experience.
+        </p>
+        <ConditionsComponet titulo="A. Order Handling and Dispatch" subtitulos={conditions[0]} />
+        <ConditionsComponet titulo="B. Delivery Times" subtitulos={conditions[1]} />
+        <ConditionsComponet titulo="C. Packaging and Fragile Items" subtitulos={conditions[2]} />
+        <ConditionsComponet titulo="D. Shipping Fees and Promotions" subtitulos={conditions[3]} />
+        <ConditionsComponet titulo="E. Customer Responsibilities" subtitulos={conditions[4]} />
+      </div>
+      <Footer />
+    </>
+  );
+}
+
+export default ShippingPolicy;


### PR DESCRIPTION
### 📄 Cuerpo del PR:

- 🎯 **Descripción:**  
Se agregaron las páginas correspondientes a los enlaces del footer que contiene /terms-conditions, /privacy, /shipping-policy, /exchange, /faq, /our-story, /contact, /returns, y se conectaron correctamente en /shop con la galería de productos.

- ✨ **Cambios realizados:**  
    - Cambio 1:  Se crearon nuevas páginas del contenid footer
    - Cambio 2:  Se actualizaron las rutas en App.jsx para que los enlaces del footer apunten a las páginas correctas.
    - Cambio 3: Se implementó un acordeón interactivo para /faq con flechas que giran al expandir/cerrar.

- 🧪 **Pasos para probar:**  
    1. Paso 1 : Iniciar la aplicación con npm 
    2. Paso 2 : Hacer clic en cada enlace del footer y verificar que redirige a la página correspondiente.
    3. Paso 3 : Revisar que el contenido de cada página se muestre correctamente
- ⚠️ **Impacto/Riesgos:**  
No hay un gran impacto, las páginas creadas son de contenido inventado cel footer; revisarlas antes de pasar a producción